### PR TITLE
Server stability and security improvements

### DIFF
--- a/src/main/java/io/github/samipourquoi/syncmatica/FileStorage.java
+++ b/src/main/java/io/github/samipourquoi/syncmatica/FileStorage.java
@@ -26,7 +26,7 @@ public class FileStorage implements IFileStorage {
 	}
 	
 	public LocalLitematicState getLocalState(ServerPlacement placement) {
-		File localFile = new File(Syncmatica.getSchematicPath(placement.getHash().toString()));
+		File localFile = new File(Syncmatica.getSchematicPath(placement));
 		if (localFile.isFile()) {
 			if (isDownloading(placement)) {
 				return LocalLitematicState.DOWNLOADING_LITEMATIC;
@@ -48,7 +48,7 @@ public class FileStorage implements IFileStorage {
 
 	public File getLocalLitematic(ServerPlacement placement) {
 		if (getLocalState(placement).isLocalFileReady()) {
-			return new File(Syncmatica.getSchematicPath(placement.getHash().toString()));
+			return new File(Syncmatica.getSchematicPath(placement));
 		} else {
 			return null;
 		}
@@ -59,7 +59,7 @@ public class FileStorage implements IFileStorage {
 		if (getLocalState(placement).isLocalFileReady()) {
 			throw new IllegalArgumentException("");
 		}
-		File file = new File(Syncmatica.getSchematicPath(placement.getHash().toString()));
+		File file = new File(Syncmatica.getSchematicPath(placement));
 		if (file.exists()) {
 			file.delete();
 		}

--- a/src/main/java/io/github/samipourquoi/syncmatica/Syncmatica.java
+++ b/src/main/java/io/github/samipourquoi/syncmatica/Syncmatica.java
@@ -20,8 +20,12 @@ public class Syncmatica {
 	private static IFileStorage data;
 	private static SyncmaticManager schematics;
 	
-	public static String getSchematicPath(String fileName) {
-		return getStoragePath()+File.separator+fileName+".litematic";
+	public static String getSchematicPath(ServerPlacement p) {
+		if (isServer) {
+			return getStoragePath()+File.separator+p.getHash().toString()+".litematic";
+		} else {
+			return getStoragePath()+File.separator+p.getName()+".litematic";
+		}
 	}
 	
 	private static String getStoragePath() {

--- a/src/main/java/io/github/samipourquoi/syncmatica/communication/Exchange/AbstractExchange.java
+++ b/src/main/java/io/github/samipourquoi/syncmatica/communication/Exchange/AbstractExchange.java
@@ -38,12 +38,17 @@ public abstract class AbstractExchange implements Exchange {
 	}
 	
 	@Override
-	public void close() {
+	public void close(boolean notifyPartner) {
 		finished = true;
 		success = false;
 		onClose();
+		if (notifyPartner) {
+			sendCancelPacket();
+		}
 	}
 	
+	protected abstract void sendCancelPacket();
+
 	protected void onClose() {
 		return;
 	}

--- a/src/main/java/io/github/samipourquoi/syncmatica/communication/Exchange/Exchange.java
+++ b/src/main/java/io/github/samipourquoi/syncmatica/communication/Exchange/Exchange.java
@@ -42,7 +42,10 @@ public interface Exchange {
 	public boolean isSuccessful();
 	
 	// marks an external unsuccessful close
-	public void close();
+	// upon a close the exchange might send a cancel packet for this request
+	// if the notifyPartner boolean is set to true
+	// otherwise this will not happen
+	public void close(boolean notifyPartner);
 	
 	// initializes the actual Exchange
 	public void init();

--- a/src/main/java/io/github/samipourquoi/syncmatica/communication/Exchange/ShareLitematicExchange.java
+++ b/src/main/java/io/github/samipourquoi/syncmatica/communication/Exchange/ShareLitematicExchange.java
@@ -33,7 +33,9 @@ public class ShareLitematicExchange extends AbstractExchange {
 	@Override
 	public boolean checkPacket(Identifier id, PacketByteBuf packetBuf) {
 		LogManager.getLogger(ClientPlayNetworkHandler.class).info("recognized possible target exchange");
-		if (id.equals(PacketType.REQUEST_LITEMATIC.IDENTIFIER)||id.equals(PacketType.REGISTER_METADATA.IDENTIFIER)) {
+		if (id.equals(PacketType.REQUEST_LITEMATIC.IDENTIFIER)
+				||id.equals(PacketType.REGISTER_METADATA.IDENTIFIER)
+				||id.equals(PacketType.CANCEL_SHARE.IDENTIFIER)) {
 			return checkUUID(packetBuf, toShare.getId());
 		}
 		return false;
@@ -53,12 +55,17 @@ public class ShareLitematicExchange extends AbstractExchange {
 				return;
 			}
 			getManager().startExchange(upload);
+			return;
 		}
 		if (id.equals(PacketType.REGISTER_METADATA.IDENTIFIER)) {
 			RedirectFileStorage redirect = (RedirectFileStorage)Syncmatica.getFileStorage();
 			redirect.addRedirect(toUpload);
-			Syncmatica.getSyncmaticManager().addPlacement(toShare);
 			LitematicManager.getInstance().renderSyncmatic(toShare, schem, false);
+			Syncmatica.getSyncmaticManager().addPlacement(toShare);
+			return;
+		}
+		if (id.equals(PacketType.CANCEL_SHARE.IDENTIFIER)) {
+			close(false);
 		}
 	}
 
@@ -73,4 +80,7 @@ public class ShareLitematicExchange extends AbstractExchange {
 	public void onClose() {
 		((ClientCommunicationManager) getManager()).setSharingState(toShare, false);
 	}
+
+	@Override
+	protected void sendCancelPacket() {}
 }

--- a/src/main/java/io/github/samipourquoi/syncmatica/communication/Exchange/VersionHandshakeClient.java
+++ b/src/main/java/io/github/samipourquoi/syncmatica/communication/Exchange/VersionHandshakeClient.java
@@ -23,7 +23,8 @@ public class VersionHandshakeClient extends AbstractExchange {
 		if (id.equals(PacketType.REGISTER_VERSION.IDENTIFIER)) {
 			String partnerVersion = packetBuf.readString(32767);
 			if (!Syncmatica.checkPartnerVersion(partnerVersion)) {
-				close();
+				// any further packets are risky so no further packets should get send
+				close(false);
 			} else {
 				PacketByteBuf newBuf = new PacketByteBuf(Unpooled.buffer());
 				newBuf.writeString(Syncmatica.VERSION);
@@ -37,5 +38,8 @@ public class VersionHandshakeClient extends AbstractExchange {
 
 	@Override
 	public void init() {}
+
+	@Override
+	protected void sendCancelPacket() {}
 
 }

--- a/src/main/java/io/github/samipourquoi/syncmatica/communication/Exchange/VersionHandshakeServer.java
+++ b/src/main/java/io/github/samipourquoi/syncmatica/communication/Exchange/VersionHandshakeServer.java
@@ -25,7 +25,8 @@ public class VersionHandshakeServer extends AbstractExchange {
 			getPartner().sendPacket(PacketType.CONFIRM_USER.IDENTIFIER, newBuf);
 			succeed();
 		} else {
-			close();
+			// same as client - avoid further packets
+			close(false);
 		}
 		
 	}
@@ -36,5 +37,8 @@ public class VersionHandshakeServer extends AbstractExchange {
 		newBuf.writeString(Syncmatica.VERSION);
 		getPartner().sendPacket(PacketType.REGISTER_VERSION.IDENTIFIER, newBuf);
 	}
+
+	@Override
+	protected void sendCancelPacket() {}
 
 }

--- a/src/main/java/io/github/samipourquoi/syncmatica/communication/PacketType.java
+++ b/src/main/java/io/github/samipourquoi/syncmatica/communication/PacketType.java
@@ -22,12 +22,16 @@ public enum PacketType {
 	// it marks the creation of a syncmatic - for now it also is responsible
 	// for changing the syncmatic server and client side
 	
+	CANCEL_SHARE("syncmatica:cancel_share"),
+	// send to a client when a share failed
+	// the client can cancel the upload or upon finishing send a removal packet
+	
 	REQUEST_LITEMATIC("syncmatica:request_download"),
 	// another group of packets will be responsible for downloading the entire
 	// litematic starting with a download request
 	
 	SEND_LITEMATIC("syncmatica:send_litematic"),
-	// a packet responsible for sending a bit of a syncmatic (32kbits to be precise (half of a TCP/IP packets size))
+	// a packet responsible for sending a bit of a litematic (16kbits to be precise (half of what minecraft can send in one packet at most))
 	
 	RECEIVED_LITEMATIC("syncmatica:received_litematic"),
 	// a packet responsible for triggering another send for a litematic
@@ -37,6 +41,10 @@ public enum PacketType {
 	FINISHED_LITEMATIC("syncmatica:finished_litematic"),
 	// a packet responsible for marking the end of a litematic
 	// transmission
+	
+	CANCEL_LITEMATIC("syncmatica:cancel_litematic"),
+	// a packet responsible for cancelling an ongoing upload/download
+	// will be sent in several cases - upon errors mostly
 	
 	REGISTER_VERSION("syncmatica:register_version"),
 	// this packet will be send to the client when it joins the server


### PR DESCRIPTION
-Fixed potential racing conditions by moving server code onto the main thread
-Added cancel packets for ongoing exchanges to signal that an exchange failed on one side due to an error
-sanitizing for file names send across the network and changes to client side storing of those files
-handling of a few edge cases with sharing to the server side