### PR TITLE
Made remove option to require shift

### DIFF
--- a/src/main/java/ch/endte/syncmatica/litematica/gui/WidgetListSyncmaticaServerPlacement.java
+++ b/src/main/java/ch/endte/syncmatica/litematica/gui/WidgetListSyncmaticaServerPlacement.java
@@ -26,9 +26,9 @@ import java.util.stream.Collectors;
 
 public class WidgetListSyncmaticaServerPlacement extends WidgetListBase<ServerPlacement, WidgetSyncmaticaServerPlacementEntry> {
 
+    public final GuiSyncmaticaServerPlacementList parent;
     private final int infoWidth;
     private final int infoHeight;
-    private final GuiSyncmaticaServerPlacementList parent;
 
     public WidgetListSyncmaticaServerPlacement(final int x, final int y, final int width, final int height, final GuiSyncmaticaServerPlacementList parent,
                                                final ISelectionListener<ServerPlacement> selectionListener) {
@@ -125,7 +125,7 @@ public class WidgetListSyncmaticaServerPlacement extends WidgetListBase<ServerPl
 
     @Override
     protected WidgetSyncmaticaServerPlacementEntry createListEntryWidget(final int x, final int y, final int listIndex, final boolean isOdd, final ServerPlacement entry) {
-        return new WidgetSyncmaticaServerPlacementEntry(x, y, browserEntryWidth, getBrowserEntryHeightFor(entry), entry, listIndex);
+        return new WidgetSyncmaticaServerPlacementEntry(x, y, browserEntryWidth, getBrowserEntryHeightFor(entry), entry, listIndex, this);
     }
 
     @Override

--- a/src/main/resources/assets/syncmatica/lang/en_us.json
+++ b/src/main/resources/assets/syncmatica/lang/en_us.json
@@ -22,5 +22,6 @@
 	"syncmatica.error.share_incompatible_schematic": "Convert this file using the Schematic Manager from the main menu to share it",
 	"syncmatica.error.invalid_file": "Cannot share this type of file",
 	"syncmatica.error.failed_to_load": "Failed to load litematic {}",
+	"syncmatica.error.remove_without_shift": "Press shift to remove from server",
 	"syncmatica.success.modification_accepted": "Modification request accept - Lock the placement again to share the results to the server"
 }


### PR DESCRIPTION
### What?
The button to remove a synced schematic from the server now requires holding shift to activate.
If shift isn't pressed when the button is activated, a message appears that states that shift is required to remove the schematic,

### Why?
On my SMP, people have removed schematics on accident too many times because they thought it would only be removed locally.
Because the placement is deleted for everyone, the owner must then replace the schematic at the correct location before anyone can continue working on it, which takes unnecessary time and effort.
Like this, people might think twice when removing the schematic and are reminded that the schematic is deleted globally. This can avoid such situation a lot of the time.